### PR TITLE
fix jump avec cam

### DIFF
--- a/Assets/Script/Child/ChildCameraController.cs
+++ b/Assets/Script/Child/ChildCameraController.cs
@@ -13,11 +13,15 @@ public class ChildCameraController : MonoBehaviour
     public float m_minPitch = -40f;
     public float m_maxPitch = 70f;
     public float m_collisionOffset = 0.2f;
+    public float m_collisionRadius = 0.2f;
+    public float m_cameraSnapSpeed = 15f;
+    public float m_cameraReturnSpeed = 4f;
     public LayerMask m_collisionMask;
     public Vector3 m_pivotOffset = new Vector3(0f, 1.6f, 0f); // approx head height
 
     public float m_yaw;
     private float m_pitch;
+    private float m_currentDistance;
     [SerializeField] private float m_xOffset;
 
     private ChildInputController m_childInputController;
@@ -36,6 +40,7 @@ public class ChildCameraController : MonoBehaviour
         m_rigidbody = GetComponentInParent<Rigidbody>();
 
         m_sensitivity = PlayerPrefs.GetFloat("Settings_MouseSensitivity", PurrLobby.AccessibilitySettingsPanel.DefaultSensitivity);
+        m_currentDistance = m_distance;
         UnityEngine.Cursor.lockState = CursorLockMode.Locked;
     }
 
@@ -62,17 +67,22 @@ public class ChildCameraController : MonoBehaviour
         desiredOffset = rotation * Vector3.back * m_distance;
         float finalDistance = m_distance;
 
-        if (Physics.Raycast(
+        if (Physics.SphereCast(
             pivot,
+            m_collisionRadius,
             desiredOffset.normalized,
             out RaycastHit hit,
             m_distance,
             m_collisionMask))
         {
-            finalDistance = hit.distance - m_collisionOffset;
+            finalDistance = Mathf.Max(0f, hit.distance - m_collisionOffset);
         }
-        Vector3 finalOffset2 = rotation * Vector3.back * finalDistance;
-        transform.position = pivot + finalOffset2;
+
+        float speed = finalDistance < m_currentDistance ? m_cameraSnapSpeed : m_cameraReturnSpeed;
+        m_currentDistance = Mathf.Lerp(m_currentDistance, finalDistance, speed * Time.deltaTime);
+
+        Vector3 finalOffset = rotation * Vector3.back * m_currentDistance;
+        transform.position = pivot + finalOffset;
         transform.LookAt(pivot);
     }
 }

--- a/Assets/Script/Child/ChildSimulateMovement.cs
+++ b/Assets/Script/Child/ChildSimulateMovement.cs
@@ -92,15 +92,13 @@ public class ChildSimulateMovement : NetworkBehaviour, ISimulateMovement
      */
     public bool IsGrounded()
     {
-        if (Physics.Raycast(transform.position, Vector3.down, out _, 1.0f) || (m_jumpTriggerScript.m_colliders.Count > 0 && m_rigidbody.linearVelocity.y == 0f))
-        {
-            if (m_rigidbody.linearVelocity.y < 1.0E-07f && m_rigidbody.linearVelocity.y > -1.0E-07f)
-            {
-                m_isJumping = false;
-            }
-            return true;
-        }
-        else return false;
+        bool onGround = Physics.Raycast(transform.position, Vector3.down, out _, 1.0f)
+                        || m_jumpTriggerScript.m_colliders.Count > 0;
+
+        if (onGround && m_isJumping && Mathf.Abs(m_rigidbody.linearVelocity.y) < 0.2f)
+            m_isJumping = false;
+
+        return onGround && !m_isJumping;
     }
 
 

--- a/Assets/Script/Ghost/GhostCameraController.cs
+++ b/Assets/Script/Ghost/GhostCameraController.cs
@@ -11,11 +11,15 @@ public class GhostCameraController : MonoBehaviour
     public float m_minPitch = -40f;
     public float m_maxPitch = 70f;
     public float m_collisionOffset = 0.2f;
+    public float m_collisionRadius = 0.2f;
+    public float m_cameraSnapSpeed = 15f;
+    public float m_cameraReturnSpeed = 4f;
     public LayerMask m_collisionMask;
     public Vector3 m_pivotOffset = new Vector3(0f, 1.6f, 0f); // approximate head height
 
     private float m_yaw;
     private float m_pitch;
+    private float m_currentDistance;
 
     private GhostInputController m_ghostInputController;
     private GhostClientController m_ghostClientController;
@@ -34,6 +38,7 @@ public class GhostCameraController : MonoBehaviour
         m_target = transform.parent;
 
         m_sensitivity = PlayerPrefs.GetFloat("Settings_MouseSensitivity", PurrLobby.AccessibilitySettingsPanel.DefaultSensitivity);
+        m_currentDistance = m_distance;
         UnityEngine.Cursor.lockState = CursorLockMode.Locked;
     }
 
@@ -52,50 +57,35 @@ public class GhostCameraController : MonoBehaviour
         Vector3 desiredOffset;
         float finalDistance = m_distance;
 
-        // Do not move the camera if the wheel is open or if reviving
         bool blockLookInput = (m_ghostClientController.m_wheel != null && m_ghostClientController.m_wheel.IsWheelOpen())
             || (m_ghostController != null && m_ghostController.m_isReviving);
-        if (blockLookInput)
+        if (!blockLookInput)
         {
-            rotation = Quaternion.Euler(m_pitch, m_yaw, 0f);
-            desiredOffset = rotation * Vector3.back * m_distance;
-
-            if (Physics.Raycast(
-                pivot,
-                desiredOffset.normalized,
-                out RaycastHit hit,
-                m_distance,
-                m_collisionMask))
-            {
-                finalDistance = hit.distance - m_collisionOffset;
-            }
-
-            Vector3 finalOffset = rotation * Vector3.back * finalDistance;
-            transform.position = pivot + finalOffset;
-            transform.LookAt(pivot);
-            return;
+            Vector2 lookInput = m_ghostInputController.m_lookInputVector;
+            m_yaw += lookInput.x * m_sensitivity * Time.deltaTime;
+            m_pitch -= lookInput.y * m_sensitivity * Time.deltaTime;
+            m_pitch = Mathf.Clamp(m_pitch, m_minPitch, m_maxPitch);
         }
-
-        Vector2 lookInput = m_ghostInputController.m_lookInputVector;
-        m_yaw += lookInput.x * m_sensitivity * Time.deltaTime;
-        m_pitch -= lookInput.y * m_sensitivity * Time.deltaTime;
-        m_pitch = Mathf.Clamp(m_pitch, m_minPitch, m_maxPitch);
 
         rotation = Quaternion.Euler(m_pitch, m_yaw, 0f);
         desiredOffset = rotation * Vector3.back * m_distance;
-        finalDistance = m_distance;
 
-        if (Physics.Raycast(
+        if (Physics.SphereCast(
             pivot,
+            m_collisionRadius,
             desiredOffset.normalized,
-            out RaycastHit hit2,
+            out RaycastHit hit,
             m_distance,
             m_collisionMask))
         {
-            finalDistance = hit2.distance - m_collisionOffset;
+            finalDistance = Mathf.Max(0f, hit.distance - m_collisionOffset);
         }
-        Vector3 finalOffset2 = rotation * Vector3.back * finalDistance;
-        transform.position = pivot + finalOffset2;
+
+        float speed = finalDistance < m_currentDistance ? m_cameraSnapSpeed : m_cameraReturnSpeed;
+        m_currentDistance = Mathf.Lerp(m_currentDistance, finalDistance, speed * Time.deltaTime);
+
+        Vector3 finalOffset = rotation * Vector3.back * m_currentDistance;
+        transform.position = pivot + finalOffset;
         transform.LookAt(pivot);
     }
 }


### PR DESCRIPTION
Jump:
- Check la vélocité avec 1.0E-07f est casse bonbon, avec 0.2 ça à l'air mieux 
- Changement du return car l'ancien était frauduleux

Caméra:
- Passage en sphérecast pour la caméra qui traverse les murs 
- lerp pour rendre plus smooth les transitions et éviter les crise épileptique
